### PR TITLE
feat: add tuppr for automated talos and kubernetes upgrades

### DIFF
--- a/.renovate/packageRules.json5
+++ b/.renovate/packageRules.json5
@@ -29,6 +29,13 @@
       "matchDatasources": ["docker"],
       "matchDepNames": ["ghcr.io/tensorchord/vchord-scratch"],
       "versioning": "regex:^pg(?<major>\\d+)-v(?<minor>\\d+)\\.(?<patch>\\d+)\\.(?<build>\\d+)$"
+    },
+    {
+      "description": ["Separate minor and patch updates for Talos and Kubernetes"],
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["ghcr.io/siderolabs/installer", "ghcr.io/siderolabs/kubelet"],
+      "separateMajorMinor": true,
+      "separateMinorPatch": true
     }
   ]
 }

--- a/kubernetes/apps/system-upgrade/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: system-upgrade
+components:
+  - ../../components/common
+resources:
+  - ./tuppr/ks.yaml

--- a/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tuppr
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: tuppr
+
+  values:
+    monitoring:
+      serviceMonitor:
+        enabled: true
+      prometheusRule:
+        enabled: true
+      dashboards:
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          matchLabels:
+            grafana.internal/instance: grafana

--- a/kubernetes/apps/system-upgrade/tuppr/app/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: tuppr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.3.2
+  url: oci://ghcr.io/home-operations/charts/tuppr

--- a/kubernetes/apps/system-upgrade/tuppr/ks.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/ks.yaml
@@ -1,0 +1,46 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tuppr
+  namespace: &namespace system-upgrade
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/system-upgrade/tuppr/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tuppr-upgrades
+  namespace: &namespace system-upgrade
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: tuppr
+  path: ./kubernetes/apps/system-upgrade/tuppr/upgrades
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  timeout: 5m

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/tuppr.home-operations.com/kubernetesupgrade_v1alpha1.json
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: KubernetesUpgrade
+metadata:
+  name: kubernetes
+spec:
+  kubernetes:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
+    version: v1.36.2
+  maintenance:
+    windows:
+      - start: "0 4 * * *"
+        duration: "4h"
+        timezone: ${TIMEZONE}

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./talosupgrade.yaml
+  - ./kubernetesupgrade.yaml

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/tuppr.home-operations.com/talosupgrade_v1alpha1.json
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: TalosUpgrade
+metadata:
+  name: talos
+spec:
+  talos:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+    version: v1.13.7
+  policy:
+    rebootMode: powercycle
+  maintenance:
+    windows:
+      - start: "0 4 * * *"
+        duration: "4h"
+        timezone: ${TIMEZONE}

--- a/talos/192.168.200.15.yaml
+++ b/talos/192.168.200.15.yaml
@@ -79,6 +79,7 @@ machine:
       allowedKubernetesNamespaces:
         - kube-system
         - actions-runner-system
+        - system-upgrade
     diskQuotaSupport: true
     kubePrism:
       enabled: true


### PR DESCRIPTION
Adds tuppr to manage Talos and Kubernetes upgrades declaratively instead of manually through the ops CLI.

- tuppr controller in a new system-upgrade namespace
- TalosUpgrade / KubernetesUpgrade CRs pinned by Renovate, daily 4am maintenance window
- Talos machine config allows Talos API access from system-upgrade (run `ops talos apply` before first upgrade)
- Renovate now separates minor/patch PRs for Talos and kubelet