### PR TITLE
fix(qbitmanage): check cross-seed, series, and movies categories for hardlinks

### DIFF
--- a/kubernetes/apps/media/qbittorrent/qbitmanage/config/config.yaml
+++ b/kubernetes/apps/media/qbittorrent/qbitmanage/config/config.yaml
@@ -49,6 +49,12 @@ nohardlinks:
       exclude_tags:
         - MaM
         - Materialize
+  - cross-seed:
+      exclude_tags:
+        - MaM
+        - Materialize
+  - series
+  - movies
 
 share_limits:
   # Torrents not in use by plex, and not "ignored" or "other"


### PR DESCRIPTION
The nohardlinks scan only covered the imported category, so cross-seed copies (88% of all torrents) kept seeding forever after their media was deleted from sonarr/radarr. Adds cross-seed (with the same MaM/Materialize exclusions), series, and movies to the scan so orphaned torrents get tagged noHL and cleaned up by the existing share limit group.