### PR TITLE
fix(talos): lower kubelet image GC thresholds for disk headroom

### DIFF
--- a/talos/192.168.200.15.yaml
+++ b/talos/192.168.200.15.yaml
@@ -17,6 +17,8 @@ machine:
     extraConfig:
       maxPods: 150
       serializeImagePulls: false
+      imageGCHighThresholdPercent: 70
+      imageGCLowThresholdPercent: 65
     defaultRuntimeSeccompProfileEnabled: true
     nodeIP:
       validSubnets:


### PR DESCRIPTION
Routine image GC now runs at 70% disk usage instead of the default 85%, keeping ~30GB of headroom before the 90% eviction threshold. Prevents a repeat of today's disk-pressure taint caused by pre-pulled renovate images riding the GC ceiling.